### PR TITLE
Fix `NoneType` error in HTML table parser when anchor tags are missing

### DIFF
--- a/pyrcs/parser.py
+++ b/pyrcs/parser.py
@@ -73,7 +73,7 @@ def _prep_records(trs, ths, sep=' / '):
 
         for td_no, td in enumerate(tds):
             if td.find('td'):
-                text_ = td.find('a').contents + ["\t\t / "]
+                text_ = [''] if td.find('a') is None else td.find('a').contents + ["\t\t / "]
             else:
                 text_ = [_parse_other_tags_in_td_contents(x) for x in td.contents]
             # _move_element_to_end(text_, char='\t\t')


### PR DESCRIPTION
Fixes `TypeError: '>' not supported between instances of 'NoneType' and 'str'` in viaduct data processing by addressing the root cause in `_prep_records`.

## Root cause
- `td.find('a')` returns `None` when no anchor tags are present
- Code attempted to access `.contents` on `None`, causing cascade of failures
- This resulted in `None` values propagating to viaduct data processing

## Changes in `_prep_records`
- Added null check: `[''] if td.find('a') is None else td.find('a').contents + ["\t\t / "]`
- Prevents `'NoneType' object has no attribute 'contents'` error
- Provides empty string as fallback for missing anchor tags

## Impact
- Resolves max date calculation error in `viaduct.fetch_codes`
- Improves robustness of HTML table parsing

## Testing
- `test_fetch_codes` now passes for viaducts with `update=True`

Closes #57 
