### PR TITLE
Lowercase URL and add timeout in get_last_updated_date()

### DIFF
--- a/pyrcs/parser.py
+++ b/pyrcs/parser.py
@@ -583,7 +583,7 @@ def get_last_updated_date(url, parsed=True, as_date_type=False, verbose=False, r
     """
 
     try:  # Request to get connected to the given url
-        source = requests.get(url=url, headers=fake_requests_headers())
+        source = requests.get(url=url.lower(), headers=fake_requests_headers(), timeout=5)
         source.raise_for_status()
     except Exception as e:
         _print_failure_message(e, verbose=verbose, raise_error=raise_error)


### PR DESCRIPTION
### Summary

This Pull Request fixes a bug in `get_last_updated_date()` where the last updated date was not being correctly retrieved due to URL case sensitivity and potential request hangs. 

### Key changes

- **URL normalisation**: Added `.lower()` to the request URL to ensure consistency with server-side expectations.
- **Request safety**: Added a `timeout=5` parameter to the `requests.get` call to prevent the parser from hanging indefinitely on unresponsive connections.
- **Bug fix**: Resolves #77.

### Testing 

- Verified that `test_get_last_updated_date()` passed successfully.