### PR TITLE
build(packaging): bundle internal data assets and config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ test = [
 # --------------------
 # Build configuration
 # --------------------
+[tool.hatch.build]
+artifacts = [
+    "pyrcs/data/**/*"
+]
+
 [tool.hatch.build.targets.sdist]
 include = [
     "pyrcs",


### PR DESCRIPTION
### Summary

Resolves a packaging issue where internal non-Python data assets residing in `pyrcs/data/` (e.g. catalogue, introduction, line-data and other assets) were excluded from built wheel and source distribution archives.


### Key Changes

**Recursive asset inclusion:** Added `artifacts` pattern `pyrcs/data/**/*` under `[tool.hatch.build]` in `pyproject.toml` to guarantee all nested data subdirectories are bundled regardless of VCS tracking status.


### Verification

Built distribution artifacts via `uv` and confirmed inclusion using archive inspection:

```bash
python -m zipfile -l dist/pyrcs-1.2.0-py3-none-any.whl | grep -E "pyrcs/(data|pyproject.toml)"
```

and

```bash
tar -tzf dist/pyrcs-1.2.0.tar.gz | grep -E "pyrcs/(data|pyproject.toml)"
```
